### PR TITLE
fix(vector_store): add threading lock to prevent concurrent FAISS access

### DIFF
--- a/src/photoaident/db/vector_store.py
+++ b/src/photoaident/db/vector_store.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Concatenate, List, ParamSpec, Tuple, TypeVar
 import numpy as np
 from faiss import IndexFlatIP, read_index, write_index
 
-
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -17,9 +16,7 @@ def _locked(
     """Decorator that acquires self._lock for the duration of the method."""
 
     @functools.wraps(method)
-    def wrapper(
-        self: "VectorStore", *args: P.args, **kwargs: P.kwargs
-    ) -> R:
+    def wrapper(self: "VectorStore", *args: P.args, **kwargs: P.kwargs) -> R:
         with self._lock:
             return method(self, *args, **kwargs)
 
@@ -60,7 +57,7 @@ class VectorStore:
             embedding = embedding.reshape(1, -1)
         elif embedding.ndim != 2:
             raise ValueError(
-                f"Embedding must be a 1D or 2D array; got {embedding.ndim}D array instead."
+                f"Embedding must be a 1D or 2D array; got {embedding.ndim}D."
             )
 
         if embedding.shape[1] != self.dimension:
@@ -91,7 +88,7 @@ class VectorStore:
             query_embedding = query_embedding.reshape(1, -1)
         elif query_embedding.ndim != 2:
             raise ValueError(
-                f"Query embedding must be a 1D or 2D array; got {query_embedding.ndim}D array instead."
+                f"Query embedding must be 1D or 2D; got {query_embedding.ndim}D."
             )
 
         if query_embedding.shape[1] != self.dimension:

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -146,16 +146,13 @@ def test_all_public_methods_are_locked():
 
 
 class _InstrumentedLock:
-    """Drop-in replacement for ``threading.Lock`` that records overlapping acquires.
+    """Drop-in replacement for ``threading.Lock`` that records peak concurrent holders.
 
-    When a thread enters ``__enter__``, if another thread already holds the lock
-    the real lock serializes them (correct behaviour). But if the lock were
-    *removed*, two threads could enter simultaneously — this class makes that
-    overlap window visible by tracking a holder count (``_holders``) under a
-    separate guard lock (``_guard``), independent of the real lock.
-
-    The real lock is still used so the test exercises the actual serialization
-    guarantee, and ``max_holders`` records the peak concurrent holder count.
+    Wraps a real ``threading.Lock`` so the test exercises actual serialization.
+    After each successful ``acquire()``, a separate ``_guard`` lock protects an
+    atomic bump of ``_holders``; ``max_holders`` captures the peak.  With the
+    real lock in place, ``max_holders`` should always be 1 — proving that all
+    ``VectorStore`` methods are properly serialized.
     """
 
     def __init__(self):


### PR DESCRIPTION
The VectorStore is shared between the indexing background thread and the UI thread (labelling, search). FAISS IndexFlatIP is not thread-safe for concurrent read+write, which could cause segfaults or corrupted data.