### PR TITLE
feat(ui): extract FilepathDateWidget and add filepath-date settings t…

### DIFF
--- a/assets/translations/photoaident_de.ts
+++ b/assets/translations/photoaident_de.ts
@@ -122,6 +122,75 @@
     </message>
 </context>
 <context>
+    <name>FilepathDateWidget</name>
+    <message>
+        <source>Date from File Path</source>
+        <translation>Datum aus Dateipfad</translation>
+    </message>
+    <message>
+        <source>Extract dates from file paths when EXIF is missing</source>
+        <translation>Datum aus Dateipfaden extrahieren, wenn EXIF fehlt</translation>
+    </message>
+    <message>
+        <source>Use placeholders to describe the date format in your folder names or file names. Supported placeholders: {YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), {DD} (2-digit day), {D} (1-or-2-digit day).
+Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</source>
+        <translation>Verwende Platzhalter, um das Datumsformat in deinen Ordner- oder Dateinamen zu beschreiben. Unterstützte Platzhalter: {YYYY} (Jahr), {MM} (2-stelliger Monat), {M} (1- oder 2-stelliger Monat), {DD} (2-stelliger Tag), {D} (1- oder 2-stelliger Tag).
+Beispiele: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</translation>
+    </message>
+    <message>
+        <source>Pattern:</source>
+        <translation>Muster:</translation>
+    </message>
+    <message>
+        <source>Pattern must not be empty.</source>
+        <translation>Muster darf nicht leer sein.</translation>
+    </message>
+    <message>
+        <source>Pattern must contain exactly one {YYYY} placeholder.</source>
+        <translation>Muster muss genau einen {YYYY}-Platzhalter enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {YYYY} more than once.</source>
+        <translation>Das Muster darf {YYYY} nicht mehr als einmal enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain both {MM} and {M}.</source>
+        <translation>Muster darf nicht sowohl {MM} als auch {M} enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must contain a month placeholder ({MM} or {M}).</source>
+        <translation>Muster muss einen Monatsplatzhalter enthalten ({MM} oder {M}).</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {MM} more than once.</source>
+        <translation>Das Muster darf {MM} nicht mehr als einmal enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {M} more than once.</source>
+        <translation>Das Muster darf {M} nicht mehr als einmal enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain both {DD} and {D}.</source>
+        <translation>Muster darf nicht sowohl {DD} als auch {D} enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must contain a day placeholder ({DD} or {D}).</source>
+        <translation>Muster muss einen Tagesplatzhalter enthalten ({DD} oder {D}).</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {DD} more than once.</source>
+        <translation>Das Muster darf {DD} nicht mehr als einmal enthalten.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {D} more than once.</source>
+        <translation>Das Muster darf {D} nicht mehr als einmal enthalten.</translation>
+    </message>
+    <message>
+        <source>Invalid Pattern</source>
+        <translation>Ungültiges Muster</translation>
+    </message>
+</context>
+<context>
     <name>GpuChecker</name>
     <message>
         <source>CPU only</source>
@@ -551,74 +620,8 @@ Bitte wähle zunächst den Ordner deiner Fotosammlung aus.</translation>
         <translation>Pfad:</translation>
     </message>
     <message>
-        <source>Date from File Path</source>
-        <translation>Datum aus Dateipfad</translation>
-    </message>
-    <message>
-        <source>Extract dates from file paths when EXIF is missing</source>
-        <translation>Datum aus Dateipfaden extrahieren, wenn EXIF fehlt</translation>
-    </message>
-    <message>
-        <source>Use placeholders to describe the date format in your folder names or file names. Supported placeholders: {YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), {DD} (2-digit day), {D} (1-or-2-digit day).
-Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</source>
-        <translation>Verwende Platzhalter, um das Datumsformat in deinen Ordner- oder Dateinamen zu beschreiben. Unterstützte Platzhalter: {YYYY} (Jahr), {MM} (2-stelliger Monat), {M} (1- oder 2-stelliger Monat), {DD} (2-stelliger Tag), {D} (1- oder 2-stelliger Tag).
-Beispiele: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</translation>
-    </message>
-    <message>
-        <source>Pattern:</source>
-        <translation>Muster:</translation>
-    </message>
-    <message>
         <source>Select Photo Collection Folder</source>
         <translation>Fotosammlungsordner auswählen</translation>
-    </message>
-    <message>
-        <source>Pattern must not be empty.</source>
-        <translation>Muster darf nicht leer sein.</translation>
-    </message>
-    <message>
-        <source>Pattern must contain exactly one {YYYY} placeholder.</source>
-        <translation>Muster muss genau einen {YYYY}-Platzhalter enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {YYYY} more than once.</source>
-        <translation>Das Muster darf {YYYY} nicht mehr als einmal enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain both {MM} and {M}.</source>
-        <translation>Muster darf nicht sowohl {MM} als auch {M} enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must contain a month placeholder ({MM} or {M}).</source>
-        <translation>Muster muss einen Monatsplatzhalter enthalten ({MM} oder {M}).</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {MM} more than once.</source>
-        <translation>Das Muster darf {MM} nicht mehr als einmal enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {M} more than once.</source>
-        <translation>Das Muster darf {M} nicht mehr als einmal enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain both {DD} and {D}.</source>
-        <translation>Muster darf nicht sowohl {DD} als auch {D} enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must contain a day placeholder ({DD} or {D}).</source>
-        <translation>Muster muss einen Tagesplatzhalter enthalten ({DD} oder {D}).</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {DD} more than once.</source>
-        <translation>Das Muster darf {DD} nicht mehr als einmal enthalten.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {D} more than once.</source>
-        <translation>Das Muster darf {D} nicht mehr als einmal enthalten.</translation>
-    </message>
-    <message>
-        <source>Invalid Pattern</source>
-        <translation>Ungültiges Muster</translation>
     </message>
 </context>
 <context>

--- a/assets/translations/photoaident_en.ts
+++ b/assets/translations/photoaident_en.ts
@@ -122,6 +122,75 @@
     </message>
 </context>
 <context>
+    <name>FilepathDateWidget</name>
+    <message>
+        <source>Date from File Path</source>
+        <translation>Date from File Path</translation>
+    </message>
+    <message>
+        <source>Extract dates from file paths when EXIF is missing</source>
+        <translation>Extract dates from file paths when EXIF is missing</translation>
+    </message>
+    <message>
+        <source>Use placeholders to describe the date format in your folder names or file names. Supported placeholders: {YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), {DD} (2-digit day), {D} (1-or-2-digit day).
+Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</source>
+        <translation>Use placeholders to describe the date format in your folder names or file names. Supported placeholders: {YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), {DD} (2-digit day), {D} (1-or-2-digit day).
+Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</translation>
+    </message>
+    <message>
+        <source>Pattern:</source>
+        <translation>Pattern:</translation>
+    </message>
+    <message>
+        <source>Pattern must not be empty.</source>
+        <translation>Pattern must not be empty.</translation>
+    </message>
+    <message>
+        <source>Pattern must contain exactly one {YYYY} placeholder.</source>
+        <translation>Pattern must contain exactly one {YYYY} placeholder.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {YYYY} more than once.</source>
+        <translation>Pattern must not contain {YYYY} more than once.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain both {MM} and {M}.</source>
+        <translation>Pattern must not contain both {MM} and {M}.</translation>
+    </message>
+    <message>
+        <source>Pattern must contain a month placeholder ({MM} or {M}).</source>
+        <translation>Pattern must contain a month placeholder ({MM} or {M}).</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {MM} more than once.</source>
+        <translation>Pattern must not contain {MM} more than once.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {M} more than once.</source>
+        <translation>Pattern must not contain {M} more than once.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain both {DD} and {D}.</source>
+        <translation>Pattern must not contain both {DD} and {D}.</translation>
+    </message>
+    <message>
+        <source>Pattern must contain a day placeholder ({DD} or {D}).</source>
+        <translation>Pattern must contain a day placeholder ({DD} or {D}).</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {DD} more than once.</source>
+        <translation>Pattern must not contain {DD} more than once.</translation>
+    </message>
+    <message>
+        <source>Pattern must not contain {D} more than once.</source>
+        <translation>Pattern must not contain {D} more than once.</translation>
+    </message>
+    <message>
+        <source>Invalid Pattern</source>
+        <translation>Invalid Pattern</translation>
+    </message>
+</context>
+<context>
     <name>GpuChecker</name>
     <message>
         <source>CPU only</source>
@@ -549,74 +618,8 @@ To get started, please select your photo collection folder.</translation>
         <translation>Path:</translation>
     </message>
     <message>
-        <source>Date from File Path</source>
-        <translation>Date from File Path</translation>
-    </message>
-    <message>
-        <source>Extract dates from file paths when EXIF is missing</source>
-        <translation>Extract dates from file paths when EXIF is missing</translation>
-    </message>
-    <message>
-        <source>Use placeholders to describe the date format in your folder names or file names. Supported placeholders: {YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), {DD} (2-digit day), {D} (1-or-2-digit day).
-Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</source>
-        <translation>Use placeholders to describe the date format in your folder names or file names. Supported placeholders: {YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), {DD} (2-digit day), {D} (1-or-2-digit day).
-Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}</translation>
-    </message>
-    <message>
-        <source>Pattern:</source>
-        <translation>Pattern:</translation>
-    </message>
-    <message>
         <source>Select Photo Collection Folder</source>
         <translation>Select Photo Collection Folder</translation>
-    </message>
-    <message>
-        <source>Pattern must not be empty.</source>
-        <translation>Pattern must not be empty.</translation>
-    </message>
-    <message>
-        <source>Pattern must contain exactly one {YYYY} placeholder.</source>
-        <translation>Pattern must contain exactly one {YYYY} placeholder.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {YYYY} more than once.</source>
-        <translation>Pattern must not contain {YYYY} more than once.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain both {MM} and {M}.</source>
-        <translation>Pattern must not contain both {MM} and {M}.</translation>
-    </message>
-    <message>
-        <source>Pattern must contain a month placeholder ({MM} or {M}).</source>
-        <translation>Pattern must contain a month placeholder ({MM} or {M}).</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {MM} more than once.</source>
-        <translation>Pattern must not contain {MM} more than once.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {M} more than once.</source>
-        <translation>Pattern must not contain {M} more than once.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain both {DD} and {D}.</source>
-        <translation>Pattern must not contain both {DD} and {D}.</translation>
-    </message>
-    <message>
-        <source>Pattern must contain a day placeholder ({DD} or {D}).</source>
-        <translation>Pattern must contain a day placeholder ({DD} or {D}).</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {DD} more than once.</source>
-        <translation>Pattern must not contain {DD} more than once.</translation>
-    </message>
-    <message>
-        <source>Pattern must not contain {D} more than once.</source>
-        <translation>Pattern must not contain {D} more than once.</translation>
-    </message>
-    <message>
-        <source>Invalid Pattern</source>
-        <translation>Invalid Pattern</translation>
     </message>
 </context>
 <context>

--- a/src/photoaident/app.py
+++ b/src/photoaident/app.py
@@ -241,13 +241,18 @@ class MainWindow(QtWidgets.QMainWindow):
         dialog = OnboardingDialog(self)
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
             return
-        if path := dialog.selected_path():
-            self._on_onboarding_accepted(path)
-
-    def _on_onboarding_accepted(self, path: str) -> None:
-        """Save the selected collection path and start the initial inventory scan."""
+        path = dialog.selected_path()
+        if not path:
+            return
         self._settings.collection_path = path
+        self._settings.filepath_date_enabled = dialog.is_filepath_date_enabled()
+        self._settings.filepath_date_pattern = dialog.get_filepath_date_pattern()
         self._settings.save(self._paths.config_file)
+        self._indexing_controller.filepath_date_pattern = (
+            self._settings.filepath_date_pattern
+            if self._settings.filepath_date_enabled
+            else ""
+        )
         self._run_inventory_scan(path)
 
     def _maybe_start_indexing(self) -> None:

--- a/src/photoaident/ui/onboarding_dialog.py
+++ b/src/photoaident/ui/onboarding_dialog.py
@@ -1,5 +1,7 @@
 from PySide6 import QtWidgets
 
+from photoaident.ui.widgets.filepath_date_widget import FilepathDateWidget
+
 
 class OnboardingDialog(QtWidgets.QDialog):
     """First-run dialog that asks the user to select their photo collection folder.
@@ -37,6 +39,10 @@ class OnboardingDialog(QtWidgets.QDialog):
         layout.addLayout(path_layout)
         layout.addSpacing(12)
 
+        self._filepath_date_widget = FilepathDateWidget(parent=self)
+        layout.addWidget(self._filepath_date_widget)
+        layout.addSpacing(12)
+
         button_box = QtWidgets.QDialogButtonBox()
         self._start_btn = button_box.addButton(
             self.tr("Start Indexing"),
@@ -58,10 +64,20 @@ class OnboardingDialog(QtWidgets.QDialog):
             self._start_btn.setEnabled(True)
 
     def _on_accept(self) -> None:
-        """Store the chosen path and accept the dialog."""
+        """Validate settings, store the chosen path, and accept the dialog."""
+        if not self._filepath_date_widget.validate():
+            return
         self._selected_path = self._path_edit.text()
         self.accept()
 
     def selected_path(self) -> str:
         """Return the folder path chosen by the user (empty string if none)."""
         return self._selected_path
+
+    def is_filepath_date_enabled(self) -> bool:
+        """Return whether filepath date extraction is enabled."""
+        return self._filepath_date_widget.is_enabled()
+
+    def get_filepath_date_pattern(self) -> str:
+        """Return the configured filepath date pattern."""
+        return self._filepath_date_widget.pattern()

--- a/src/photoaident/ui/preferences_dialog.py
+++ b/src/photoaident/ui/preferences_dialog.py
@@ -1,10 +1,6 @@
 from PySide6 import QtWidgets
 
-from photoaident.core.filepath_date import (
-    PatternErrorCode,
-    PatternValidationError,
-    compile_pattern,
-)
+from photoaident.ui.widgets.filepath_date_widget import FilepathDateWidget
 
 
 class PreferencesDialog(QtWidgets.QDialog):
@@ -44,44 +40,11 @@ class PreferencesDialog(QtWidgets.QDialog):
         layout.addWidget(group)
 
         # Date from File Path setting
-        date_group = QtWidgets.QGroupBox(self.tr("Date from File Path"), self)
-        date_layout = QtWidgets.QVBoxLayout(date_group)
-
-        self._filepath_date_checkbox = QtWidgets.QCheckBox(
-            self.tr("Extract dates from file paths when EXIF is missing"), self
+        self._filepath_date_widget = FilepathDateWidget(
+            filepath_date_enabled, filepath_date_pattern, self
         )
-        self._filepath_date_checkbox.setChecked(filepath_date_enabled)
-        date_layout.addWidget(self._filepath_date_checkbox)
-
-        instructions = QtWidgets.QLabel(
-            self.tr(
-                "Use placeholders to describe the date format in your folder names "
-                "or file names. Supported placeholders: "
-                "{YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), "
-                "{DD} (2-digit day), {D} (1-or-2-digit day).\n"
-                "Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}"
-            ),
-            self,
-        )
-        instructions.setWordWrap(True)
-        date_layout.addWidget(instructions)
-
-        pattern_row = QtWidgets.QHBoxLayout()
-        pattern_label = QtWidgets.QLabel(self.tr("Pattern:"), self)
-        self._filepath_date_pattern_edit = QtWidgets.QLineEdit(
-            filepath_date_pattern, self
-        )
-        self._filepath_date_pattern_edit.setPlaceholderText("{YYYY}-{MM}-{DD}")
-        pattern_row.addWidget(pattern_label)
-        pattern_row.addWidget(self._filepath_date_pattern_edit)
-        date_layout.addLayout(pattern_row)
-
-        layout.addWidget(date_group)
+        layout.addWidget(self._filepath_date_widget)
         layout.addStretch()
-
-        # Enable/disable pattern widgets based on checkbox state
-        self._set_date_widgets_enabled(filepath_date_enabled)
-        self._filepath_date_checkbox.toggled.connect(self._set_date_widgets_enabled)
 
         # OK / Cancel buttons
         self.button_box = QtWidgets.QDialogButtonBox(
@@ -93,9 +56,6 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.button_box.rejected.connect(self.reject)
         layout.addWidget(self.button_box)
 
-    def _set_date_widgets_enabled(self, enabled: bool) -> None:
-        self._filepath_date_pattern_edit.setEnabled(enabled)
-
     def _browse_path(self):
         """Open a directory selection dialog."""
         current_path = self.path_edit.text()
@@ -105,56 +65,10 @@ class PreferencesDialog(QtWidgets.QDialog):
         if directory:
             self.path_edit.setText(directory)
 
-    def _translate_pattern_error(self, code: PatternErrorCode) -> str:
-        """Return a translated error message for the given validation error code."""
-        messages: dict[PatternErrorCode, str] = {
-            PatternErrorCode.EMPTY: self.tr("Pattern must not be empty."),
-            PatternErrorCode.YEAR_MISSING: self.tr(
-                "Pattern must contain exactly one {YYYY} placeholder."
-            ),
-            PatternErrorCode.YEAR_DUPLICATE: self.tr(
-                "Pattern must not contain {YYYY} more than once."
-            ),
-            PatternErrorCode.MONTH_CONFLICT: self.tr(
-                "Pattern must not contain both {MM} and {M}."
-            ),
-            PatternErrorCode.MONTH_MISSING: self.tr(
-                "Pattern must contain a month placeholder ({MM} or {M})."
-            ),
-            PatternErrorCode.MONTH_MM_DUPLICATE: self.tr(
-                "Pattern must not contain {MM} more than once."
-            ),
-            PatternErrorCode.MONTH_M_DUPLICATE: self.tr(
-                "Pattern must not contain {M} more than once."
-            ),
-            PatternErrorCode.DAY_CONFLICT: self.tr(
-                "Pattern must not contain both {DD} and {D}."
-            ),
-            PatternErrorCode.DAY_MISSING: self.tr(
-                "Pattern must contain a day placeholder ({DD} or {D})."
-            ),
-            PatternErrorCode.DAY_DD_DUPLICATE: self.tr(
-                "Pattern must not contain {DD} more than once."
-            ),
-            PatternErrorCode.DAY_D_DUPLICATE: self.tr(
-                "Pattern must not contain {D} more than once."
-            ),
-        }
-        return messages[code]
-
     def accept(self) -> None:
         """Validate settings before closing. Block if the pattern is invalid."""
-        if self._filepath_date_checkbox.isChecked():
-            pattern = self._filepath_date_pattern_edit.text().strip()
-            try:
-                compile_pattern(pattern)
-            except PatternValidationError as exc:
-                QtWidgets.QMessageBox.warning(
-                    self,
-                    self.tr("Invalid Pattern"),
-                    self._translate_pattern_error(exc.code),
-                )
-                return
+        if not self._filepath_date_widget.validate():
+            return
         super().accept()
 
     def get_collection_path(self) -> str:
@@ -163,8 +77,8 @@ class PreferencesDialog(QtWidgets.QDialog):
 
     def is_filepath_date_enabled(self) -> bool:
         """Return whether filepath date extraction is enabled."""
-        return self._filepath_date_checkbox.isChecked()
+        return self._filepath_date_widget.is_enabled()
 
     def get_filepath_date_pattern(self) -> str:
         """Return the configured filepath date pattern."""
-        return self._filepath_date_pattern_edit.text().strip()
+        return self._filepath_date_widget.pattern()

--- a/src/photoaident/ui/widgets/filepath_date_widget.py
+++ b/src/photoaident/ui/widgets/filepath_date_widget.py
@@ -1,0 +1,127 @@
+from PySide6 import QtWidgets
+
+from photoaident.core.filepath_date import (
+    PatternErrorCode,
+    PatternValidationError,
+    compile_pattern,
+)
+
+
+class FilepathDateWidget(QtWidgets.QWidget):
+    """Reusable widget for the 'Date from File Path' settings section.
+
+    Encapsulates the checkbox, instructions label, and pattern field used in
+    both :class:`PreferencesDialog` and :class:`OnboardingDialog`.
+    """
+
+    def __init__(
+        self,
+        enabled: bool = False,
+        pattern: str = "",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        group = QtWidgets.QGroupBox(self.tr("Date from File Path"), self)
+        date_layout = QtWidgets.QVBoxLayout(group)
+
+        self._checkbox = QtWidgets.QCheckBox(
+            self.tr("Extract dates from file paths when EXIF is missing"), self
+        )
+        self._checkbox.setChecked(enabled)
+        date_layout.addWidget(self._checkbox)
+
+        instructions = QtWidgets.QLabel(
+            self.tr(
+                "Use placeholders to describe the date format in your folder names "
+                "or file names. Supported placeholders: "
+                "{YYYY} (year), {MM} (2-digit month), {M} (1-or-2-digit month), "
+                "{DD} (2-digit day), {D} (1-or-2-digit day).\n"
+                "Examples: {YYYY}-{MM}-{DD}  ·  {DD}.{M}.{YYYY}  ·  PXL{YYYY}{MM}{DD}"
+            ),
+            self,
+        )
+        instructions.setWordWrap(True)
+        date_layout.addWidget(instructions)
+
+        pattern_row = QtWidgets.QHBoxLayout()
+        pattern_label = QtWidgets.QLabel(self.tr("Pattern:"), self)
+        self._pattern_edit = QtWidgets.QLineEdit(pattern, self)
+        self._pattern_edit.setPlaceholderText("{YYYY}-{MM}-{DD}")
+        pattern_row.addWidget(pattern_label)
+        pattern_row.addWidget(self._pattern_edit)
+        date_layout.addLayout(pattern_row)
+
+        outer_layout = QtWidgets.QVBoxLayout(self)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.addWidget(group)
+
+        self._set_pattern_enabled(enabled)
+        self._checkbox.toggled.connect(self._set_pattern_enabled)
+
+    def _set_pattern_enabled(self, enabled: bool) -> None:
+        self._pattern_edit.setEnabled(enabled)
+
+    def _translate_pattern_error(self, code: PatternErrorCode) -> str:
+        """Return a translated error message for the given validation error code."""
+        messages: dict[PatternErrorCode, str] = {
+            PatternErrorCode.EMPTY: self.tr("Pattern must not be empty."),
+            PatternErrorCode.YEAR_MISSING: self.tr(
+                "Pattern must contain exactly one {YYYY} placeholder."
+            ),
+            PatternErrorCode.YEAR_DUPLICATE: self.tr(
+                "Pattern must not contain {YYYY} more than once."
+            ),
+            PatternErrorCode.MONTH_CONFLICT: self.tr(
+                "Pattern must not contain both {MM} and {M}."
+            ),
+            PatternErrorCode.MONTH_MISSING: self.tr(
+                "Pattern must contain a month placeholder ({MM} or {M})."
+            ),
+            PatternErrorCode.MONTH_MM_DUPLICATE: self.tr(
+                "Pattern must not contain {MM} more than once."
+            ),
+            PatternErrorCode.MONTH_M_DUPLICATE: self.tr(
+                "Pattern must not contain {M} more than once."
+            ),
+            PatternErrorCode.DAY_CONFLICT: self.tr(
+                "Pattern must not contain both {DD} and {D}."
+            ),
+            PatternErrorCode.DAY_MISSING: self.tr(
+                "Pattern must contain a day placeholder ({DD} or {D})."
+            ),
+            PatternErrorCode.DAY_DD_DUPLICATE: self.tr(
+                "Pattern must not contain {DD} more than once."
+            ),
+            PatternErrorCode.DAY_D_DUPLICATE: self.tr(
+                "Pattern must not contain {D} more than once."
+            ),
+        }
+        return messages[code]
+
+    def is_enabled(self) -> bool:
+        """Return whether date extraction from file paths is enabled."""
+        return self._checkbox.isChecked()
+
+    def pattern(self) -> str:
+        """Return the configured pattern, stripped of whitespace."""
+        return self._pattern_edit.text().strip()
+
+    def validate(self) -> bool:
+        """Validate the current state.
+
+        Returns True if valid or the checkbox is unchecked. When checked with
+        an invalid pattern, shows a warning dialog and returns False.
+        """
+        if not self._checkbox.isChecked():
+            return True
+        try:
+            compile_pattern(self.pattern())
+        except PatternValidationError as exc:
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("Invalid Pattern"),
+                self._translate_pattern_error(exc.code),
+            )
+            return False
+        return True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -222,7 +222,7 @@ def test_onboarding_not_triggered_when_path_set(qtbot, tmp_app_paths, monkeypatc
 def test_onboarding_accepted_saves_settings_and_starts_scan(
     qtbot, tmp_app_paths, monkeypatch
 ):
-    """_on_onboarding_accepted persists the path and kicks off the inventory scan."""
+    """_show_onboarding persists the path and kicks off the inventory scan."""
     collection_dir = _make_collection_dir(tmp_app_paths)
 
     window = _make_window(tmp_app_paths, qtbot)
@@ -232,7 +232,13 @@ def test_onboarding_accepted_saves_settings_and_starts_scan(
         window, "_run_inventory_scan", lambda p: scan_called_with.append(p)
     )
 
-    window._on_onboarding_accepted(str(collection_dir))
+    def mock_exec(self):
+        self._selected_path = str(collection_dir)
+        return QtWidgets.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(OnboardingDialog, "exec", mock_exec)
+
+    window._show_onboarding()
 
     assert window._settings.collection_path == str(collection_dir)
     assert scan_called_with == [str(collection_dir)]
@@ -334,16 +340,17 @@ def test_show_onboarding_cancelled_does_nothing(tmp_app_paths, qtbot, monkeypatc
         "exec",
         lambda _self: QtWidgets.QDialog.DialogCode.Rejected,
     )
-    called: list[str] = []
-    monkeypatch.setattr(window, "_on_onboarding_accepted", lambda p: called.append(p))
+    scan_called: list[str] = []
+    monkeypatch.setattr(window, "_run_inventory_scan", lambda p: scan_called.append(p))
 
     window._show_onboarding()
 
-    assert called == []
+    assert scan_called == []
+    assert window._settings.collection_path == ""
 
 
 def test_show_onboarding_accepted_calls_handler(tmp_app_paths, qtbot, monkeypatch):
-    """_show_onboarding calls _on_onboarding_accepted with the chosen folder."""
+    """_show_onboarding saves the path and starts an inventory scan when accepted."""
     collection_dir = _make_collection_dir(tmp_app_paths)
 
     window = _make_window(tmp_app_paths, qtbot)
@@ -353,12 +360,13 @@ def test_show_onboarding_accepted_calls_handler(tmp_app_paths, qtbot, monkeypatc
         return QtWidgets.QDialog.DialogCode.Accepted
 
     monkeypatch.setattr(OnboardingDialog, "exec", fake_exec)
-    called: list[str] = []
-    monkeypatch.setattr(window, "_on_onboarding_accepted", lambda p: called.append(p))
+    scan_called: list[str] = []
+    monkeypatch.setattr(window, "_run_inventory_scan", lambda p: scan_called.append(p))
 
     window._show_onboarding()
 
-    assert called == [str(collection_dir)]
+    assert scan_called == [str(collection_dir)]
+    assert window._settings.collection_path == str(collection_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_filepath_date_widget.py
+++ b/tests/test_filepath_date_widget.py
@@ -1,0 +1,186 @@
+"""Tests for FilepathDateWidget."""
+
+from unittest.mock import MagicMock
+
+from PySide6 import QtWidgets
+
+from photoaident.core.filepath_date import PatternErrorCode
+from photoaident.ui.widgets.filepath_date_widget import FilepathDateWidget
+
+# ===========================================================================
+# Initial state
+# ===========================================================================
+
+
+def test_defaults_disabled_empty_pattern(qtbot):
+    """Widget defaults to disabled checkbox and empty pattern."""
+    w = FilepathDateWidget()
+    qtbot.addWidget(w)
+    assert not w.is_enabled()
+    assert w.pattern() == ""
+
+
+def test_initial_enabled_and_pattern(qtbot):
+    """Constructor arguments are reflected in widget state."""
+    w = FilepathDateWidget(enabled=True, pattern="{YYYY}/{MM}/{DD}")
+    qtbot.addWidget(w)
+    assert w.is_enabled()
+    assert w.pattern() == "{YYYY}/{MM}/{DD}"
+
+
+def test_initial_disabled_pattern_field_disabled(qtbot):
+    """Pattern field is disabled when the checkbox starts unchecked."""
+    w = FilepathDateWidget(enabled=False)
+    qtbot.addWidget(w)
+    assert not w._pattern_edit.isEnabled()
+
+
+def test_initial_enabled_pattern_field_enabled(qtbot):
+    """Pattern field is enabled when the checkbox starts checked."""
+    w = FilepathDateWidget(enabled=True)
+    qtbot.addWidget(w)
+    assert w._pattern_edit.isEnabled()
+
+
+# ===========================================================================
+# is_enabled / checkbox toggle
+# ===========================================================================
+
+
+def test_is_enabled_reflects_checkbox(qtbot):
+    """is_enabled() tracks the checkbox state."""
+    w = FilepathDateWidget(enabled=False)
+    qtbot.addWidget(w)
+
+    w._checkbox.setChecked(True)
+    assert w.is_enabled()
+
+    w._checkbox.setChecked(False)
+    assert not w.is_enabled()
+
+
+def test_checkbox_toggle_enables_pattern_field(qtbot):
+    """Toggling the checkbox enables/disables the pattern field."""
+    w = FilepathDateWidget(enabled=False)
+    qtbot.addWidget(w)
+
+    w._checkbox.setChecked(True)
+    assert w._pattern_edit.isEnabled()
+
+    w._checkbox.setChecked(False)
+    assert not w._pattern_edit.isEnabled()
+
+
+# ===========================================================================
+# pattern()
+# ===========================================================================
+
+
+def test_pattern_returns_stripped_text(qtbot):
+    """pattern() strips leading/trailing whitespace."""
+    w = FilepathDateWidget(pattern="  {YYYY}-{MM}-{DD}  ")
+    qtbot.addWidget(w)
+    assert w.pattern() == "{YYYY}-{MM}-{DD}"
+
+
+def test_pattern_returns_empty_when_blank(qtbot):
+    """pattern() returns an empty string when the field is blank."""
+    w = FilepathDateWidget(pattern="   ")
+    qtbot.addWidget(w)
+    assert w.pattern() == ""
+
+
+# ===========================================================================
+# validate()
+# ===========================================================================
+
+
+def test_validate_returns_true_when_unchecked(qtbot):
+    """validate() is True regardless of pattern when unchecked."""
+    w = FilepathDateWidget(enabled=False, pattern="")
+    qtbot.addWidget(w)
+    assert w.validate() is True
+
+
+def test_validate_returns_true_when_unchecked_invalid_pattern(qtbot):
+    """validate() skips pattern check when unchecked, even with bad pattern."""
+    w = FilepathDateWidget(enabled=False, pattern="no-placeholders")
+    qtbot.addWidget(w)
+    assert w.validate() is True
+
+
+def test_validate_returns_true_when_checked_and_valid(qtbot):
+    """validate() returns True when checked and pattern is valid."""
+    w = FilepathDateWidget(enabled=True, pattern="{YYYY}-{MM}-{DD}")
+    qtbot.addWidget(w)
+    assert w.validate() is True
+
+
+def test_validate_returns_false_when_checked_and_empty(qtbot, monkeypatch):
+    """validate() returns False and shows warning when pattern is empty."""
+    w = FilepathDateWidget(enabled=True, pattern="")
+    qtbot.addWidget(w)
+
+    mock_warning = MagicMock()
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", mock_warning)
+
+    result = w.validate()
+
+    assert result is False
+    mock_warning.assert_called_once()
+
+
+def test_validate_returns_false_when_pattern_missing_year(qtbot, monkeypatch):
+    """validate() returns False when {YYYY} is absent."""
+    w = FilepathDateWidget(enabled=True, pattern="{MM}-{DD}")
+    qtbot.addWidget(w)
+
+    mock_warning = MagicMock()
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", mock_warning)
+
+    assert w.validate() is False
+    call_args = mock_warning.call_args[0]
+    assert w.tr("Pattern must contain exactly one {YYYY} placeholder.") in call_args
+
+
+def test_validate_does_not_show_warning_when_valid(qtbot, monkeypatch):
+    """validate() does not call QMessageBox.warning on a valid pattern."""
+    w = FilepathDateWidget(enabled=True, pattern="{YYYY}-{MM}-{DD}")
+    qtbot.addWidget(w)
+
+    mock_warning = MagicMock()
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", mock_warning)
+
+    w.validate()
+
+    mock_warning.assert_not_called()
+
+
+# ===========================================================================
+# _translate_pattern_error — covers every PatternErrorCode
+# ===========================================================================
+
+
+def test_translate_pattern_error_empty(qtbot):
+    w = FilepathDateWidget()
+    qtbot.addWidget(w)
+    assert w._translate_pattern_error(PatternErrorCode.EMPTY) == w.tr(
+        "Pattern must not be empty."
+    )
+
+
+def test_translate_pattern_error_year_missing(qtbot):
+    w = FilepathDateWidget()
+    qtbot.addWidget(w)
+    assert w._translate_pattern_error(PatternErrorCode.YEAR_MISSING) == w.tr(
+        "Pattern must contain exactly one {YYYY} placeholder."
+    )
+
+
+def test_translate_pattern_error_covers_all_codes(qtbot):
+    """_translate_pattern_error returns a non-empty string for every error code."""
+    w = FilepathDateWidget()
+    qtbot.addWidget(w)
+    for code in PatternErrorCode:
+        msg = w._translate_pattern_error(code)
+        assert isinstance(msg, str) and msg

--- a/tests/test_onboarding_dialog.py
+++ b/tests/test_onboarding_dialog.py
@@ -84,3 +84,94 @@ def test_on_accept_with_empty_path(qtbot, monkeypatch):
     dlg._on_accept()
 
     assert dlg.selected_path() == ""
+
+
+# ===========================================================================
+# FilepathDateWidget presence and integration
+# ===========================================================================
+
+
+def test_filepath_date_widget_present(qtbot):
+    """The dialog contains a FilepathDateWidget."""
+    from photoaident.ui.widgets.filepath_date_widget import FilepathDateWidget
+
+    dlg = OnboardingDialog()
+    qtbot.addWidget(dlg)
+    assert isinstance(dlg._filepath_date_widget, FilepathDateWidget)
+
+
+def test_on_accept_blocks_on_invalid_pattern(qtbot, monkeypatch):
+    """_on_accept() does not call accept() when the pattern is invalid."""
+    dlg = OnboardingDialog()
+    qtbot.addWidget(dlg)
+
+    dlg._path_edit.setText("/my/photos")
+    dlg._filepath_date_widget._checkbox.setChecked(True)
+    dlg._filepath_date_widget._pattern_edit.setText("")  # invalid: empty
+
+    mock_warning = MagicMock()
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", mock_warning)
+
+    accept_called: list[bool] = []
+    monkeypatch.setattr(dlg, "accept", lambda: accept_called.append(True))
+
+    dlg._on_accept()
+
+    mock_warning.assert_called_once()
+    assert accept_called == []
+    assert dlg.selected_path() == ""  # not stored
+
+
+def test_on_accept_succeeds_with_valid_pattern(qtbot, monkeypatch):
+    """_on_accept() proceeds when the checkbox is checked and pattern is valid."""
+    dlg = OnboardingDialog()
+    qtbot.addWidget(dlg)
+
+    dlg._path_edit.setText("/my/photos")
+    dlg._filepath_date_widget._checkbox.setChecked(True)
+    dlg._filepath_date_widget._pattern_edit.setText("{YYYY}-{MM}-{DD}")
+
+    accept_called: list[bool] = []
+    monkeypatch.setattr(dlg, "accept", lambda: accept_called.append(True))
+
+    dlg._on_accept()
+
+    assert accept_called == [True]
+    assert dlg.selected_path() == "/my/photos"
+
+
+def test_on_accept_succeeds_when_checkbox_unchecked(qtbot, monkeypatch):
+    """_on_accept() proceeds when the checkbox is unchecked regardless of pattern."""
+    dlg = OnboardingDialog()
+    qtbot.addWidget(dlg)
+
+    dlg._path_edit.setText("/my/photos")
+    # checkbox is unchecked by default; pattern is empty — no validation
+
+    accept_called: list[bool] = []
+    monkeypatch.setattr(dlg, "accept", lambda: accept_called.append(True))
+
+    dlg._on_accept()
+
+    assert accept_called == [True]
+
+
+def test_accessor_delegation_enabled(qtbot, monkeypatch):
+    """is_filepath_date_enabled() delegates to the widget."""
+    dlg = OnboardingDialog()
+    qtbot.addWidget(dlg)
+
+    dlg._filepath_date_widget._checkbox.setChecked(True)
+    assert dlg.is_filepath_date_enabled() is True
+
+    dlg._filepath_date_widget._checkbox.setChecked(False)
+    assert dlg.is_filepath_date_enabled() is False
+
+
+def test_accessor_delegation_pattern(qtbot, monkeypatch):
+    """get_filepath_date_pattern() delegates to the widget."""
+    dlg = OnboardingDialog()
+    qtbot.addWidget(dlg)
+
+    dlg._filepath_date_widget._pattern_edit.setText("  {YYYY}/{MM}/{DD}  ")
+    assert dlg.get_filepath_date_pattern() == "{YYYY}/{MM}/{DD}"

--- a/tests/test_preferences_dialog.py
+++ b/tests/test_preferences_dialog.py
@@ -158,7 +158,8 @@ def test_translate_pattern_error_empty(qtbot):
     """EMPTY code maps to the 'must not be empty' translated string."""
     dialog = PreferencesDialog("/path", 0, 0)
     qtbot.add_widget(dialog)
-    assert dialog._translate_pattern_error(PatternErrorCode.EMPTY) == dialog.tr(
+    widget = dialog._filepath_date_widget
+    assert widget._translate_pattern_error(PatternErrorCode.EMPTY) == widget.tr(
         "Pattern must not be empty."
     )
 
@@ -167,7 +168,8 @@ def test_translate_pattern_error_year_missing(qtbot):
     """YEAR_MISSING code maps to the missing-year translated string."""
     dialog = PreferencesDialog("/path", 0, 0)
     qtbot.add_widget(dialog)
-    assert dialog._translate_pattern_error(PatternErrorCode.YEAR_MISSING) == dialog.tr(
+    widget = dialog._filepath_date_widget
+    assert widget._translate_pattern_error(PatternErrorCode.YEAR_MISSING) == widget.tr(
         "Pattern must contain exactly one {YYYY} placeholder."
     )
 
@@ -176,8 +178,9 @@ def test_translate_pattern_error_covers_all_codes(qtbot):
     """_translate_pattern_error returns a non-empty string for every error code."""
     dialog = PreferencesDialog("/path", 0, 0)
     qtbot.add_widget(dialog)
+    widget = dialog._filepath_date_widget
     for code in PatternErrorCode:
-        msg = dialog._translate_pattern_error(code)
+        msg = widget._translate_pattern_error(code)
         assert isinstance(msg, str) and msg
 
 


### PR DESCRIPTION
…o onboarding

Move the 'Date from File Path' group box, validation logic, and error translation out of PreferencesDialog into a reusable FilepathDateWidget, then embed it in OnboardingDialog so users can configure filepath-date extraction on first run.

- New FilepathDateWidget with is_enabled(), pattern(), validate() API
- PreferencesDialog delegates to FilepathDateWidget (no behaviour change)
- OnboardingDialog gains FilepathDateWidget + accessor methods
- _show_onboarding inlined (_on_onboarding_accepted removed), now saves filepath_date_enabled/pattern from onboarding into settings
- i18n: 16 strings moved from PreferencesDialog context to FilepathDateWidget
- Tests: new test_filepath_date_widget.py; onboarding/preferences/app tests updated