### PR TITLE
feat: auto-preselect best-matching person and cluster in LabellingDialog

### DIFF
--- a/src/photoaident/core/search_person.py
+++ b/src/photoaident/core/search_person.py
@@ -209,6 +209,40 @@ def _load_person_cluster_means(
     return person_names, person_means
 
 
+def find_best_person_for_face(
+    face_id: int,
+    session_factory: "sessionmaker",
+    vector_store: "VectorStore",
+) -> int | None:
+    """Return the person_id whose cluster mean best matches the face embedding.
+
+    Loads all persisted cluster means in a single DB query and computes cosine
+    similarity against the face embedding retrieved from *vector_store*.  Returns
+    ``None`` when no cluster means are available or the face has no embedding.
+
+    Args:
+        face_id: Database Face.id of the face to match.
+        session_factory: SQLAlchemy session factory.
+        vector_store: FAISS vector store holding face embeddings.
+
+    Returns:
+        The ``person_id`` of the best-matching person, or ``None``.
+    """
+    try:
+        embedding = vector_store.get_embedding(face_id)
+    except IndexError:
+        return None
+
+    _, person_means = _load_person_cluster_means(session_factory)
+    if not person_means:
+        return None
+
+    means_matrix = np.stack([emb for _, emb in person_means])  # (M, D)
+    scores = embedding @ means_matrix.T  # (M,)
+    best_idx = int(np.argmax(scores))
+    return person_means[best_idx][0]
+
+
 def resolve_faces_to_persons(
     face_ids: list[int],
     session_factory: "sessionmaker",

--- a/src/photoaident/core/search_person.py
+++ b/src/photoaident/core/search_person.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -10,6 +11,8 @@ from sqlalchemy import select
 from photoaident.db.cluster_means import deserialize_embedding
 from photoaident.db.database import EmbeddingCluster, Face, Person
 from photoaident.db.vector_store import FACE_MATCH_THRESHOLD
+
+logger = logging.getLogger(__name__)
 
 _SQLITE_IN_LIMIT = 900  # SQLite bound-parameter limit is 999; stay safely below it
 
@@ -238,6 +241,19 @@ def find_best_person_for_face(
         return None
 
     means_matrix = np.stack([emb for _, emb in person_means])  # (M, D)
+
+    if (
+        hasattr(vector_store, "dimension")
+        and vector_store.dimension != means_matrix.shape[1]
+    ):
+        logger.error(
+            "find_best_person_for_face: VectorStore dimension (%d) does not match "
+            "persisted cluster means dimension (%d) — skipping match",
+            vector_store.dimension,
+            means_matrix.shape[1],
+        )
+        return None
+
     scores = embedding @ means_matrix.T  # (M,)
     best_idx = int(np.argmax(scores))
     return person_means[best_idx][0]

--- a/src/photoaident/ui/widgets/labelling_dialog.py
+++ b/src/photoaident/ui/widgets/labelling_dialog.py
@@ -10,6 +10,7 @@ from PySide6 import QtWidgets
 from sqlalchemy import select
 from sqlalchemy.orm import contains_eager, selectinload
 
+from photoaident.core.search_person import find_best_person_for_face
 from photoaident.db.cluster_means import deserialize_embedding, recompute_cluster_mean
 from photoaident.ui.window_state import restore_widget_geometry, save_widget_geometry
 from photoaident.db.database import (
@@ -277,7 +278,11 @@ class LabellingDialog(QtWidgets.QDialog):
         self._image_preview.load(entry.image_path, entry.bbox)
         self._face_crop.load(entry.crop_path, entry.image_path, entry.bbox)
         self._set_buttons_enabled(True)
-        self._refresh_cluster_selection()
+        best_person_id = self._find_best_person_id()
+        if best_person_id is not None:
+            self._person_widget.select_by_id(best_person_id)
+        else:
+            self._refresh_cluster_selection()
 
     def _advance_to_next(self) -> None:
         """Remove the current face from the list and show the next unidentified face."""
@@ -371,6 +376,14 @@ class LabellingDialog(QtWidgets.QDialog):
 
         self._person_widget.add_person_sorted(loaded)
         self._person_widget.select_by_id(new_person_id)
+
+    def _find_best_person_id(self) -> int | None:
+        """Return the person_id whose cluster mean best matches the current face."""
+        if self._current_face_id is None:
+            return None
+        return find_best_person_for_face(
+            self._current_face_id, self._session_factory, self._vector_store
+        )
 
     def _compute_cluster_scores(
         self, cluster_by_age: dict[str, EmbeddingCluster]

--- a/src/photoaident/ui/widgets/labelling_dialog.py
+++ b/src/photoaident/ui/widgets/labelling_dialog.py
@@ -284,8 +284,12 @@ class LabellingDialog(QtWidgets.QDialog):
         best_person_id = self._find_best_person_id()
         if best_person_id is not None:
             self._person_widget.select_by_id(best_person_id)
-        else:
-            self._refresh_cluster_selection()
+        # Unconditionally sync _selected_person from the widget and refresh
+        # cluster scores for this face.  Qt suppresses currentItemChanged when
+        # the same item is re-selected, so we cannot rely on the signal alone
+        # when the best-match person is the same across consecutive faces.
+        self._selected_person = self._person_widget.current_person()
+        self._refresh_cluster_selection()
 
     def _advance_to_next(self) -> None:
         """Remove the current face from the list and show the next unidentified face."""

--- a/src/photoaident/ui/widgets/labelling_dialog.py
+++ b/src/photoaident/ui/widgets/labelling_dialog.py
@@ -278,6 +278,9 @@ class LabellingDialog(QtWidgets.QDialog):
         self._image_preview.load(entry.image_path, entry.bbox)
         self._face_crop.load(entry.crop_path, entry.image_path, entry.bbox)
         self._set_buttons_enabled(True)
+        self._person_widget.clear_selection()
+        self._cluster_widget.clear_data()
+        self._search_edit.clear()
         best_person_id = self._find_best_person_id()
         if best_person_id is not None:
             self._person_widget.select_by_id(best_person_id)

--- a/src/photoaident/ui/widgets/person_list_widget.py
+++ b/src/photoaident/ui/widgets/person_list_widget.py
@@ -68,6 +68,13 @@ class PersonListWidget(QtWidgets.QWidget):
         """Deselect all items and emit person_selected(None)."""
         self._list_widget.setCurrentRow(-1)
 
+    def current_person(self) -> Person | None:
+        """Return the currently selected Person, or None if nothing is selected."""
+        item = self._list_widget.currentItem()
+        if item is None:
+            return None
+        return item.data(QtCore.Qt.ItemDataRole.UserRole)  # type: ignore[return-value]
+
     def current_filter_text(self) -> str:
         """Return the current search field text."""
         return self._search_edit.text()

--- a/tests/test_labelling_dialog.py
+++ b/tests/test_labelling_dialog.py
@@ -1006,3 +1006,149 @@ def test_face_info_label_cleared_in_empty_state(
     qtbot.addWidget(dialog)
 
     assert dialog._face_info_label.text() == ""
+
+
+# ===========================================================================
+# Auto-preselect best person + cluster
+# ===========================================================================
+
+
+def test_preselect_best_person_and_cluster_on_open(
+    qtbot, session_factory, tmp_app_paths, vector_store
+):
+    """Opening the dialog auto-selects the person whose cluster mean best matches
+    the face embedding, and pre-selects the best-scoring age cluster, so Confirm
+    is enabled without any user interaction."""
+    # Create an unidentified face whose embedding points along axis 1 (unit_emb(1))
+    img_id = _insert_image(session_factory, "/presel.jpg", "preselhash")
+    face_emb = _unit_emb(1)
+    with session_factory() as session:
+        face = Face(
+            image_id=img_id,
+            bbox_x=0,
+            bbox_y=0,
+            bbox_w=40,
+            bbox_h=40,
+            detection_confidence=0.9,
+            state=FaceState.UNIDENTIFIED,
+            model_version="test",
+        )
+        session.add(face)
+        session.flush()
+        vector_store.add(face.id, face_emb)
+        session.commit()
+
+    # Person A — cluster mean along axis 0 (orthogonal to face_emb)
+    _, cluster_a_id = _insert_person_with_cluster(session_factory, "Alice", "adult")
+    with session_factory() as session:
+        ca = session.get(EmbeddingCluster, cluster_a_id)
+        ca.mean_embedding = serialize_embedding(_unit_emb(0))
+        session.commit()
+
+    # Person B — cluster mean along axis 1 (identical direction to face_emb → score 1.0)
+    person_b_id, cluster_b_id = _insert_person_with_cluster(
+        session_factory, "Bob", "adult"
+    )
+    with session_factory() as session:
+        cb = session.get(EmbeddingCluster, cluster_b_id)
+        cb.mean_embedding = serialize_embedding(_unit_emb(1))
+        session.commit()
+
+    dialog = _make_dialog(session_factory, tmp_app_paths, vector_store, img_id)
+    qtbot.addWidget(dialog)
+
+    # Bob should be auto-selected because his cluster mean is closest to face_emb
+    assert dialog._selected_person is not None
+    assert dialog._selected_person.id == person_b_id
+    # Best-matching cluster (adult) should also be selected, enabling Confirm
+    assert dialog._selected_cluster is not None
+    assert dialog.confirm_btn.isEnabled()
+
+
+def test_no_preselection_when_no_cluster_means(
+    qtbot, session_factory, tmp_app_paths, vector_store
+):
+    """When no cluster means have been persisted yet, the dialog opens with no
+    person or cluster pre-selected (existing fall-through behaviour)."""
+    face_id, image_id = _insert_face(session_factory)
+    vector_store.add(face_id, _ones_norm_emb())
+
+    # Person exists but has no identified faces → mean_embedding is NULL
+    _insert_person_with_cluster(session_factory, "Zara", "adult")
+
+    dialog = _make_dialog(session_factory, tmp_app_paths, vector_store, image_id)
+    qtbot.addWidget(dialog)
+
+    assert dialog._selected_person is None
+    assert dialog._selected_cluster is None
+    assert not dialog.confirm_btn.isEnabled()
+
+
+def test_preselect_recomputed_on_face_advance(
+    qtbot, session_factory, tmp_app_paths, vector_store
+):
+    """After advancing to the next face, preselection is re-evaluated for that
+    face's embedding, not the previous face's."""
+    image_id = _insert_image(session_factory, "/advpre.jpg", "advprehash")
+
+    # Face 1 — embedding along axis 0; shown first (lower bbox_x)
+    with session_factory() as session:
+        face1 = Face(
+            image_id=image_id,
+            bbox_x=0,
+            bbox_y=0,
+            bbox_w=40,
+            bbox_h=40,
+            detection_confidence=0.9,
+            state=FaceState.UNIDENTIFIED,
+            model_version="test",
+        )
+        session.add(face1)
+        session.flush()
+        face1_id = face1.id
+        vector_store.add(face1_id, _unit_emb(0))
+        session.commit()
+
+    # Face 2 — embedding along axis 1; shown second (higher bbox_x)
+    with session_factory() as session:
+        face2 = Face(
+            image_id=image_id,
+            bbox_x=50,
+            bbox_y=0,
+            bbox_w=40,
+            bbox_h=40,
+            detection_confidence=0.9,
+            state=FaceState.UNIDENTIFIED,
+            model_version="test",
+        )
+        session.add(face2)
+        session.flush()
+        face2_id = face2.id
+        vector_store.add(face2_id, _unit_emb(1))
+        session.commit()
+
+    # Person B — cluster mean along axis 1, only close to face 2
+    person_b_id, cluster_b_id = _insert_person_with_cluster(
+        session_factory, "Bob2", "adult"
+    )
+    with session_factory() as session:
+        cb = session.get(EmbeddingCluster, cluster_b_id)
+        cb.mean_embedding = serialize_embedding(_unit_emb(1))
+        session.commit()
+
+    dialog = _make_dialog(session_factory, tmp_app_paths, vector_store, image_id)
+    qtbot.addWidget(dialog)
+
+    # Face 1 is shown first; no cluster mean is close (axis 0 vs axis 1 = score 0)
+    # But B is still the best available option, so it gets preselected
+    assert dialog._current_face_id == face1_id
+
+    # Mark face 1 anonymous → dialog advances to face 2
+    dialog._mark_anonymous()
+
+    assert dialog._current_face_id == face2_id
+    # Face 2 embedding aligns perfectly with Bob2's cluster mean
+    assert dialog._selected_person is not None
+    assert dialog._selected_person.id == person_b_id
+    assert dialog._selected_cluster is not None
+    assert dialog.confirm_btn.isEnabled()

--- a/tests/test_search_person.py
+++ b/tests/test_search_person.py
@@ -446,3 +446,22 @@ def test_find_best_person_for_face_missing_embedding(search_db, vector_store):
 
     result = find_best_person_for_face(99999, search_db, vector_store)
     assert result is None
+
+
+def test_find_best_person_for_face_dimension_mismatch(search_db, vector_store, caplog):
+    """Returns None and logs an error when dimensions differ."""
+    import logging
+
+    person_id, cluster_id = _add_person_cluster(search_db)
+    _add_identified_face(search_db, vector_store, person_id, cluster_id, _unit_emb(0))
+
+    _, face_id = _add_unidentified_face(search_db, vector_store, _unit_emb(0))
+
+    # Simulate a mismatched dimension on the vector store
+    vector_store.dimension = vector_store.dimension + 1
+
+    with caplog.at_level(logging.ERROR, logger="photoaident.core.search_person"):
+        result = find_best_person_for_face(face_id, search_db, vector_store)
+
+    assert result is None
+    assert any("dimension" in record.message for record in caplog.records)

--- a/tests/test_search_person.py
+++ b/tests/test_search_person.py
@@ -8,6 +8,7 @@ import photoaident.core.search as search_module
 from photoaident.core.search import search_images
 from photoaident.core.search_person import (
     _intersect_and_rank,
+    find_best_person_for_face,
     resolve_faces_to_persons,
     _find_images_by_person,
 )
@@ -405,3 +406,43 @@ def test_resolve_faces_stale_face_id(search_db, vector_store):
     # face_id 9999 does not exist in vector store → IndexError path → maps to None
     result = resolve_faces_to_persons([9999], search_db, vector_store, threshold=0.0)
     assert result == {9999: None}
+
+
+# ===========================================================================
+# find_best_person_for_face
+# ===========================================================================
+
+
+def test_find_best_person_for_face_returns_closest(search_db, vector_store):
+    """Returns the person_id whose cluster mean is closest to the face embedding."""
+    person_a_id, cluster_a_id = _add_person_cluster(search_db)
+    _add_identified_face(
+        search_db, vector_store, person_a_id, cluster_a_id, _unit_emb(0)
+    )
+
+    person_b_id, cluster_b_id = _add_person_cluster(search_db)
+    _add_identified_face(
+        search_db, vector_store, person_b_id, cluster_b_id, _unit_emb(1)
+    )
+
+    _, face_id = _add_unidentified_face(search_db, vector_store, _unit_emb(1))
+
+    result = find_best_person_for_face(face_id, search_db, vector_store)
+    assert result == person_b_id
+
+
+def test_find_best_person_for_face_no_cluster_means(search_db, vector_store):
+    """Returns None when no cluster means have been persisted."""
+    _, face_id = _add_unidentified_face(search_db, vector_store, _unit_emb(0))
+    # No persons/clusters in DB → no means → None
+    result = find_best_person_for_face(face_id, search_db, vector_store)
+    assert result is None
+
+
+def test_find_best_person_for_face_missing_embedding(search_db, vector_store):
+    """Returns None when the face has no embedding in the vector store."""
+    person_id, cluster_id = _add_person_cluster(search_db)
+    _add_identified_face(search_db, vector_store, person_id, cluster_id, _unit_emb(0))
+
+    result = find_best_person_for_face(99999, search_db, vector_store)
+    assert result is None


### PR DESCRIPTION
When a face is shown for labelling, the dialog now automatically selects the person whose cluster mean embedding is closest (cosine similarity) to the current face, and pre-selects the best-scoring age-group cluster, so the user only needs to click Confirm in the common case.

The similarity lookup is implemented as `find_best_person_for_face` in `core/search_person.py`, reusing the existing `_load_person_cluster_means` helper and FAISS vector store — no math lives in the UI layer.